### PR TITLE
[FEAT] Add the build and push of the same Docker image but with latest as ta…

### DIFF
--- a/.github/workflows/publish-prod.yml
+++ b/.github/workflows/publish-prod.yml
@@ -49,9 +49,11 @@ jobs:
       # 🏗️ Step 5: Build the Docker image
       - name: Build Docker image
         run: |
-          docker build -t ${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.tag }} .
+          docker build -t ${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.tag }} \
+                       -t ${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.IMAGE_NAME }}:latest .
 
       # 🚀 Step 6: Push the Docker image to Artifact Registry
       - name: Push Docker image
         run: |
           docker push ${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.tag }}
+          docker push ${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.IMAGE_NAME }}:latest


### PR DESCRIPTION
…g for Airflow convenience

## 🚀 Summary
<!-- Briefly describe the changes made in this PR. -->
This PR adds the tag _latest_ to the Docker image on production so that on Airflow, I'll be able to always point at the latest Docker image. I'll keep the images with the actual GitHub release too. 

## 📌 Changes Included
<!-- List the key modifications in this PR -->
- [x] New features (non-breaking changes)

## 📂 Files Changed
<!-- List key files modified, added, or deleted -->
- `publish-prod.yml`

## 🛠 How to Test
<!-- Steps to test the changes locally -->
1. Pull the latest changes:  
   ```bash
   git fetch origin feat/add_last_docker_image_tag_on_prod_for_airflow_convenience
   git checkout feat/add_last_docker_image_tag_on_prod_for_airflow_convenience

